### PR TITLE
fix: Check if the entry is file

### DIFF
--- a/v1/install.sh
+++ b/v1/install.sh
@@ -142,6 +142,7 @@ curl -sL "$url" | tar xz -f - -C "$td"
 
 for f in "$td"/*; do
     test -x "$f" || continue
+    test -f "$f" || continue
 
     if [ -e "$dest/$(basename f)" ] && [ $force = false ]; then
         err "$f already exists in $dest"


### PR DESCRIPTION
To fix "Inappropriate file type or format" error on directory. I've faced this to install crate-ci/typos