### PR TITLE
chore(ci): Fix renovatebot's commit messages

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,6 +3,7 @@
     'before 3am on the first day of the month',
   ],
   semanticCommits: 'enabled',
+  commitMessageLowerCase: 'never',
   configMigration: true,
   dependencyDashboard: true,
 }


### PR DESCRIPTION
From https://github.com/crate-ci/gh-install/actions/runs/7373872130/job/20063612969

docs: https://docs.renovatebot.com/configuration-options/#commitmessagelowercase
